### PR TITLE
add function Map_Thread_Port_Variable_Name

### DIFF
--- a/src/backends/ocarina-backends-c_common-ba.adb
+++ b/src/backends/ocarina-backends-c_common-ba.adb
@@ -834,11 +834,6 @@ package body Ocarina.Backends.C_Common.BA is
                                      & " the REQUEST_PORT macro. ");
                Append_Node_To_List (N, Statements);
 
-               Get_Name_String (CTU.To_C_Name
-                                (AIN.Display_Name (AIN.Identifier (S))));
-               Add_Str_To_Name_Buffer ("_thread");
-               N1 := Name_Find;
-
                CTU.Append_Node_To_List
                  (Make_Assignment_Statement
                     (Variable_Identifier => Make_Member_Designator
@@ -849,7 +844,8 @@ package body Ocarina.Backends.C_Common.BA is
                      Expression          => Make_Call_Profile
                        (RE (RE_REQUEST_PORT),
                         Make_List_Id
-                          (Make_Defining_Identifier (N1),
+                          (Make_Defining_Identifier
+                               (Map_Thread_Port_Variable_Name (S)),
                            Make_Defining_Identifier
                              (BATN.Display_Name (BATN.First_Node
                               (BATN.Idt (BATN.Identifier (Node)))))))),
@@ -867,14 +863,11 @@ package body Ocarina.Backends.C_Common.BA is
                                            & " following similar pattern. ");
                      Append_Node_To_List (N, Statements);
 
-                     Get_Name_String (CTU.To_C_Name
-                                      (AIN.Display_Name (AIN.Identifier (S))));
-                     Add_Str_To_Name_Buffer ("_thread");
-                     N1 := Name_Find;
                      N := Make_Call_Profile
                        (RE (RE_PORT_VARIABLE),
                         Make_List_Id
-                          (Make_Defining_Identifier (N1),
+                          (Make_Defining_Identifier
+                               (Map_Thread_Port_Variable_Name (S)),
                            Make_Defining_Identifier
                              (BATN.Display_Name (BATN.First_Node
                               (BATN.Idt (BATN.Identifier (Node)))))));
@@ -910,16 +903,12 @@ package body Ocarina.Backends.C_Common.BA is
                N := Make_Defining_Identifier (N1);
                Append_Node_To_List (N, Call_Parameters);
 
-               Get_Name_String (CTU.To_C_Name
-                                (AIN.Display_Name (AIN.Identifier (S))));
-               Add_Str_To_Name_Buffer ("_thread");
-               N1 := Name_Find;
-
                Append_Node_To_List
                  (Make_Call_Profile
                     (RE (RE_Local_Port),
                      Make_List_Id
-                       (Make_Defining_Identifier (N1),
+                       (Make_Defining_Identifier
+                            (Map_Thread_Port_Variable_Name (S)),
                         Make_Defining_Identifier
                           (BATN.Display_Name (BATN.First_Node
                            (BATN.Idt (BATN.Identifier (Node))))))),
@@ -1659,17 +1648,12 @@ package body Ocarina.Backends.C_Common.BA is
             N := Make_Defining_Identifier (N1);
             Append_Node_To_List (N, Call_Parameters);
 
-            Get_Name_String (CTU.To_C_Name
-                             (AIN.Display_Name
-                                (AIN.Identifier (Subprogram_Root))));
-            Add_Str_To_Name_Buffer ("_thread");
-            N1 := Name_Find;
-
             Append_Node_To_List
               (Make_Call_Profile
                  (RE (RE_Local_Port),
                   Make_List_Id
-                    (Make_Defining_Identifier (N1),
+                    (Make_Defining_Identifier
+                         (Map_Thread_Port_Variable_Name (Subprogram_Root)),
                      Make_Defining_Identifier (BATN.Display_Name (Node)))),
                Call_Parameters);
 
@@ -1694,17 +1678,12 @@ package body Ocarina.Backends.C_Common.BA is
                N := Make_Defining_Identifier (N1);
                Append_Node_To_List (N, Call_Parameters);
 
-               Get_Name_String (CTU.To_C_Name
-                                  (AIN.Display_Name
-                                     (AIN.Identifier (Subprogram_Root))));
-               Add_Str_To_Name_Buffer ("_thread");
-               N1 := Name_Find;
-
                Append_Node_To_List
                  (Make_Call_Profile
                     (RE (RE_Local_Port),
                      Make_List_Id
-                       (Make_Defining_Identifier (N1),
+                       (Make_Defining_Identifier
+                            (Map_Thread_Port_Variable_Name (Subprogram_Root)),
                         Make_Defining_Identifier
                           (BATN.Display_Name (Node)))),
                   Call_Parameters);
@@ -1718,15 +1697,10 @@ package body Ocarina.Backends.C_Common.BA is
 
             Call_Parameters := New_List (CTN.K_Parameter_List);
 
-            Get_Name_String (CTU.To_C_Name
-                               (AIN.Display_Name
-                                  (AIN.Identifier (Subprogram_Root))));
-            Add_Str_To_Name_Buffer ("_thread");
-            N1 := Name_Find;
-
             Append_Node_To_List
-            (Make_Defining_Identifier (N1),
-             Call_Parameters);
+              (Make_Defining_Identifier
+                 (Map_Thread_Port_Variable_Name (Subprogram_Root)),
+               Call_Parameters);
 
             Append_Node_To_List
               (Make_Defining_Identifier (BATN.Display_Name (Node)),

--- a/src/backends/ocarina-backends-c_common-mapping.adb
+++ b/src/backends/ocarina-backends-c_common-mapping.adb
@@ -4409,4 +4409,21 @@ package body Ocarina.Backends.C_Common.Mapping is
       return To_Lower (Converted);
    end Map_ASN_Type;
 
+   -----------------------------------
+   -- Map_Thread_Port_Variable_Name --
+   -----------------------------------
+
+   function Map_Thread_Port_Variable_Name
+     (E : Node_Id) return Name_Id
+   is
+      Converted : Name_Id;
+   begin
+      Get_Name_String (CTU.To_C_Name
+                         (Display_Name (Identifier (E))));
+
+      Add_Str_To_Name_Buffer ("_thread");
+      Converted := Name_Find;
+      return To_Lower (Converted);
+   end Map_Thread_Port_Variable_Name;
+
 end Ocarina.Backends.C_Common.Mapping;

--- a/src/backends/ocarina-backends-c_common-mapping.ads
+++ b/src/backends/ocarina-backends-c_common-mapping.ads
@@ -391,4 +391,8 @@ package Ocarina.Backends.C_Common.Mapping is
    function Map_ASN_Type (ASN_Name : Name_Id) return Name_Id;
    --  Map the name of an ASN.1 type into the C mapping.
 
+   function Map_Thread_Port_Variable_Name (E : Node_Id) return Name_Id;
+   --  Map the thread identifier name into a variable name
+   --  that is used in port sending or reading.
+
 end Ocarina.Backends.C_Common.Mapping;


### PR DESCRIPTION
Add function Map_Thread_Port_Variable_Name that map the thread identifier name into a variable name that is used in port sending or reading. 
