### PR TITLE
solve the problem of data_component_classifier used only in the scope of BA

### DIFF
--- a/src/core/instance/ocarina-instances.adb
+++ b/src/core/instance/ocarina-instances.adb
@@ -321,6 +321,7 @@ package body Ocarina.Instances is
       while Present (List_Node) loop
          if No (Default_Instance (List_Node)) then
             if ATE.Get_Category_Of_Component (List_Node) = CC_Subprogram
+              or else ATE.Get_Category_Of_Component (List_Node) = CC_Data
             then
                Set_Instance (List_Node,
                              Instantiate_Component (Instance_Root, List_Node));


### PR DESCRIPTION
solve the problem of data_component_classifier used only in the scope of a BA, that can be a type of either a BA variable or a counter of For/ForAll construct.
Indeed, the definition of the corresponding C type is defined in subprograms.c file.
The generated code is compiling.