### PR TITLE
Fix bug in mapping port name in ba expression

### DIFF
--- a/src/backends/ocarina-backends-c_common-mapping.adb
+++ b/src/backends/ocarina-backends-c_common-mapping.adb
@@ -4419,9 +4419,9 @@ package body Ocarina.Backends.C_Common.Mapping is
       Converted : Name_Id;
    begin
       Get_Name_String (CTU.To_C_Name
-                         (Display_Name (Identifier (E))));
+                       (Display_Name (Identifier
+                          (Parent_Subcomponent (E)))));
 
-      Add_Str_To_Name_Buffer ("_thread");
       Converted := Name_Find;
       return To_Lower (Converted);
    end Map_Thread_Port_Variable_Name;

--- a/src/core/model/ocarina-analyzer-aadl_ba.adb
+++ b/src/core/model/ocarina-analyzer-aadl_ba.adb
@@ -2752,6 +2752,16 @@ package body Ocarina.Analyzer.AADL_BA is
                BA_Root          => BA_Root,
                Parent_Component => Parent_Component);
 
+         elsif BATN.Kind (Node) = BATN.K_Value_Expression then
+            Success := Analyze_BA_Value_Expression
+              (Node              => Node,
+               Root              => Root,
+               BA_Root           => BA_Root,
+               Parent_Component  => Parent_Component,
+               Is_Parameter_Expr => Is_Parameter_Expr,
+               Is_Out_Parameter  => Is_Out_Parameter,
+               Parameter_Type    => Parameter_Type,
+               Scope_BA_Entities => Scope_BA_Entities);
          end if;
 
       end if;


### PR DESCRIPTION
Add the analysis of BA_Value_Expression in the case of BA_Value. Thus, we have the link of port name when we have K_Value_Expression in a K_Value node. Therefore, the mapping will be correct.