### PR TITLE
Support nested lists in property values

### DIFF
--- a/src/backends/aadl_pp/ocarina-be_aadl-properties.adb
+++ b/src/backends/aadl_pp/ocarina-be_aadl-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2008-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2020 OpenAADL                 --
+--                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -291,6 +291,36 @@ package body Ocarina.BE_AADL.Properties is
       Write_Eol;
    end Print_Property_Type_Declaration;
 
+   -------------------------------
+   -- Print_Property_List_Value --
+   -------------------------------
+
+   procedure Print_Property_List_Value (Node : Node_Id) is
+      pragma Assert (Kind (Node) = K_Property_List_Value);
+
+      List_Node : Node_Id;
+   begin
+      Print_Token (T_Left_Parenthesis);
+      List_Node := First_Node (Property_Values (Node));
+
+      while Present (List_Node) loop
+         if List_Node /= First_Node (Property_Values (Node)) then
+            Print_Token (T_Comma);
+            Write_Space;
+         end if;
+
+         if Kind (List_Node) = K_Property_List_Value then
+            Print_Property_List_Value (List_Node);
+         else
+            Print_Property_Value (List_Node);
+         end if;
+
+         List_Node := Next_Node (List_Node);
+      end loop;
+
+      Print_Token (T_Right_Parenthesis);
+   end Print_Property_List_Value;
+
    ---------------------------
    -- Print_Property_Values --
    ---------------------------
@@ -300,25 +330,15 @@ package body Ocarina.BE_AADL.Properties is
         (Present (Node)
          and then (Kind (Node) = K_Property_Value or else DNKE (Node)));
 
-      List_Node : Node_Id;
+      Prop_List_Value_Node : Node_Id;
    begin
       if Single_Value (Node) = No_Node then
-         --  Print Property_List_Value with new line and indents
+         --  Print Property_List_Value
 
-         Print_Token (T_Left_Parenthesis);
-         List_Node := First_Node (Multi_Value (Node));
-
-         while Present (List_Node) loop
-            if List_Node /= First_Node (Multi_Value (Node)) then
-               Print_Token (T_Comma);
-               Write_Space;
-            end if;
-
-            Print_Property_Value (List_Node);
-            List_Node := Next_Node (List_Node);
-         end loop;
-
-         Print_Token (T_Right_Parenthesis);
+         Prop_List_Value_Node :=
+           New_Node (K_Property_List_Value, Loc (Node));
+         Set_Property_Values (Prop_List_Value_Node, Multi_Value (Node));
+         Print_Property_List_Value (Prop_List_Value_Node);
       else
          --  Print Property_Expression without new line
 

--- a/src/core/instance/ocarina-instances-processor-properties.adb
+++ b/src/core/instance/ocarina-instances-processor-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2005-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2020 OpenAADL                 --
+--                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -248,6 +248,7 @@ package body Ocarina.Instances.Processor.Properties is
         (No (Property_Value)
          or else Kind (Property_Value) = K_Literal
          or else Kind (Property_Value) = K_Property_Term
+         or else Kind (Property_Value) = K_Property_List_Value
          or else Kind (Property_Value) = K_Enumeration_Term
          or else Kind (Property_Value) = K_Number_Range_Term
          or else Kind (Property_Value) = K_Reference_Term
@@ -628,6 +629,30 @@ package body Ocarina.Instances.Processor.Properties is
                Set_List_Items
                  (Evaluated_Value,
                   ATN.List_Items (Property_Value));
+
+            when K_Property_List_Value =>
+               declare
+                  Items              : List_Id;
+                  Item               : Node_Id;
+                  New_Evaluated_Node : Node_Id;
+               begin
+                  Items :=
+                    New_List (K_List_Id, ATN.Loc (Property_Value));
+                  Item :=
+                    ATN.First_Node (Property_Values (Property_Value));
+                  while Item /= No_Node loop
+                     New_Evaluated_Node :=
+                       Evaluate_Property_Value
+                         (Instance_Root, Container, Item);
+                     Append_Node_To_List (New_Evaluated_Node, Items);
+                     Item := ATN.Next_Node (Item);
+                  end loop;
+                  Evaluated_Value :=
+                    New_Node
+                      (K_Property_List_Value,
+                       ATN.Loc (Property_Value));
+                  Set_Property_Values (Evaluated_Value, Items);
+               end;
 
             when others =>
                raise Program_Error;

--- a/src/core/model/ocarina-builder-aadl-properties.adb
+++ b/src/core/model/ocarina-builder-aadl-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --                  Copyright (C) 2009 Telecom ParisTech,                   --
---                 2010-2019 ESA & ISAE, 2019-2020 OpenAADL                 --
+--                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -418,7 +418,7 @@ package body Ocarina.Builder.AADL.Properties is
                Set_Single_Value (Value_Of_Association, No_Node);
                Set_Multi_Value
                  (Value_Of_Association,
-                  List_Id (Property_Value));
+                  Property_Values (Property_Value));
             else
                Set_Single_Value (Value_Of_Association, Property_Value);
                Set_Multi_Value (Value_Of_Association, No_List);

--- a/src/core/model/ocarina-processor-properties.adb
+++ b/src/core/model/ocarina-processor-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2005-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2020 OpenAADL                 --
+--                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -513,6 +513,11 @@ package body Ocarina.Processor.Properties is
                   Append_List_To_List
                     (List_Id (Computed_Value),
                      Expanded_List);
+               elsif Kind (Computed_Value) = K_Property_List_Value then
+                  --  nested lists
+                  Append_Node_To_List
+                    (Computed_Value,
+                     Expanded_List);
                else
                   Expanded_List_Node := Computed_Value;
 
@@ -564,6 +569,7 @@ package body Ocarina.Processor.Properties is
          or else Kind (Property_Value) = K_Component_Classifier_Term
          or else Kind (Property_Value) = K_Unique_Property_Const_Identifier
          or else Kind (Property_Value) = K_Record_Term
+         or else Kind (Property_Value) = K_Property_List_Value
          or else Ocarina.ME_AADL.AADL_Tree.Entities.DNKE (Property_Value));
 
       pragma Assert (Reference_Property /= No_Node);
@@ -575,6 +581,26 @@ package body Ocarina.Processor.Properties is
          Evaluated_Value := No_Node;
       else
          case Kind (Property_Value) is
+            when K_Property_List_Value =>
+               declare
+                  Items              : List_Id;
+                  Item               : Node_Id;
+                  New_Evaluated_Node : Node_Id;
+               begin
+                  Items := New_List (K_List_Id, Loc (Property_Value));
+                  Item := First_Node (Property_Values (Property_Value));
+                  while Item /= No_Node loop
+                     New_Evaluated_Node :=
+                       Evaluate_Property_Value (Item, Reference_Property);
+                     Append_Node_To_List (New_Evaluated_Node, Items);
+                     Item := Next_Node (Item);
+                  end loop;
+
+                  Evaluated_Value :=
+                    New_Node (K_Property_List_Value, Loc (Property_Value));
+                  Set_Property_Values (Evaluated_Value, Items);
+               end;
+
             when K_Enumeration_Term =>
                Evaluated_Value :=
                  New_Node (Kind (Property_Value), Loc (Property_Value));

--- a/src/core/tree/ocarina-me_aadl-aadl_tree-entities-properties.adb
+++ b/src/core/tree/ocarina-me_aadl-aadl_tree-entities-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2008-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2020 OpenAADL                 --
+--                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -262,6 +262,7 @@ package body Ocarina.ME_AADL.AADL_Tree.Entities.Properties is
       pragma Assert
         (No (Property_Value)
          or else Kind (Property_Value) = K_Property_Value
+         or else Kind (Property_Value) = K_Property_List_Value
          or else Kind (Property_Value) = K_Literal
          or else Kind (Property_Value) = K_Minus_Numeric_Term
          or else Kind (Property_Value) = K_Signed_AADLNumber
@@ -320,6 +321,12 @@ package body Ocarina.ME_AADL.AADL_Tree.Entities.Properties is
                Value_Node := No_Node;
             end if;
          end if;
+
+      elsif Kind (Property_Value) = K_Property_List_Value then
+         Value_Node := First_Node (Property_Values (Property_Value));
+         while Kind (Value_Node) = K_Property_List_Value loop
+            Value_Node := First_Node (Property_Values (Value_Node));
+         end loop;
 
       else
          Value_Node := Property_Value;

--- a/src/core/tree/ocarina-me_aadl-aadl_tree-nodes.idl
+++ b/src/core/tree/ocarina-me_aadl-aadl_tree-nodes.idl
@@ -4,7 +4,8 @@
 **                                                                          **
 **                        O C A R I N A . N O D E S                         **
 **                                                                          **
-**    Copyright (C) 2004-2009, GET-Telecom Paris, 2010-2016 ESA & ISAE.     **
+**                Copyright (C) 2004-2009, GET-Telecom Paris,               **
+**                   2010-2016 ESA & ISAE, 2021 OpenAADL                    **
 **                                                                          **
 ** Ocarina  is free software;  you  can  redistribute  it and/or  modify    **
 ** it under terms of the GNU General Public License as published by the     **
@@ -1253,10 +1254,10 @@ module Ocarina::ME_AADL::AADL_Tree::Nodes {
   //                                   | memory_classifier_reference
   //                                   | bus_classsifer_reference
 
-  interface Property_List_Value : List_Id { };
-  //  interface Property_List_Value : Node_Id {
-  //  List_Id Property_Values;
-  //};
+  //interface Property_List_Value : List_Id { };
+  interface Property_List_Value : Node_Id {
+    List_Id Property_Values;
+  };
 
   //  XXX Change to inherit from Node_Id, list being an internal field
   /*

--- a/src/frontends/aadl/ocarina-fe_aadl-parser-properties.adb
+++ b/src/frontends/aadl/ocarina-fe_aadl-parser-properties.adb
@@ -93,31 +93,29 @@ package body Ocarina.FE_AADL.Parser.Properties is
 
          if Token = T_Right_Parenthesis then
             --  Property_List_Value is empty
-            Prop_Value := Node_Id (New_List (K_List_Id, Loc));
-            Set_Kind (Prop_Value, K_Property_List_Value);
-            Set_First_Node (List_Id (Prop_Value), No_Node);
-            Set_Last_Node (List_Id (Prop_Value), No_Node);
+            Prop_Value := New_Node (K_Property_List_Value, Loc);
+            Set_Property_Values (Prop_Value, New_List (K_List_Id, Loc));
+            Set_First_Node (Property_Values (Prop_Value), No_Node);
+            Set_Last_Node (Property_Values (Prop_Value), No_Node);
          else
             Restore_Lexer (Loc);
 
-            --  Prop_Value :=
-            --  Node_Id (P_Items_List (P_Property_Value'Access,
+            Prop_Value := New_Node (K_Property_List_Value, Loc);
+            Set_Property_Values
+              (Prop_Value,
+               P_Items_List
+                 (P_Property_Expression'Access,
+                  No_Node,
+                  T_Comma,
+                  T_Right_Parenthesis,
+                  PC_Property_List_Value));
 
-            Prop_Value :=
-              Node_Id
-                (P_Items_List
-                   (P_Property_Expression'Access,
-                    No_Node,
-                    T_Comma,
-                    T_Right_Parenthesis,
-                    PC_Property_List_Value));
             if No (Prop_Value) then
                --  error when parsing Property_Expression list, quit
                Skip_Tokens (T_Semicolon);
                return No_Node;
             end if;
 
-            Set_Kind (Prop_Value, K_Property_List_Value);
          end if;
 
       else

--- a/tests/github/issue_282/MANIFEST
+++ b/tests/github/issue_282/MANIFEST
@@ -1,0 +1,3 @@
+AADL_VERSION=-aadlv2
+OCARINA_FLAGS=-g aadl
+

--- a/tests/github/issue_282/test.aadl
+++ b/tests/github/issue_282/test.aadl
@@ -3,3 +3,18 @@ property set Test_List_of_List_Properties is
   a_list_of_list_of_list_property: list of list of list of aadlinteger applies to (system);
   a_list_of_list_of_list_of_list_property: list of list of list of list of aadlinteger applies to (system);
 end Test_List_of_List_Properties;
+package Test_List_of_List
+public
+    with Test_List_of_List_Properties;
+
+    system main
+    end main;
+
+    system implementation main.impl
+        properties
+            Test_List_of_List_Properties::a_list_of_list_property => ((1,2), (3,4));
+            Test_List_of_List_Properties::a_list_of_list_of_list_property => (((1,2),(3,4)),((5,6),(7,8)));
+            Test_List_of_List_Properties::a_list_of_list_of_list_of_list_property => ((((1,2)),((3,4))),(((5,6)),((7,8))));
+    end main.impl;
+
+end Test_List_of_List;

--- a/tests/github/issue_282/test.aadl.out
+++ b/tests/github/issue_282/test.aadl.out
@@ -18,3 +18,21 @@ property set Test_List_of_List_Properties is
 
 end Test_List_of_List_Properties;
 
+package Test_List_of_List
+public
+  with Test_List_of_List_Properties;
+
+  system main
+  end main;
+
+  system implementation main.impl
+  properties
+    Test_List_of_List_Properties::a_list_of_list_property => ((1, 2), (3, 4));
+    Test_List_of_List_Properties::a_list_of_list_of_list_property => (((1, 2), (3, 4)), ((5, 6), (7, 8)));
+    Test_List_of_List_Properties::a_list_of_list_of_list_of_list_property => ((((1, 2)), ((3, 4))), (((5, 6)), ((7, 8))));
+
+  end main.impl;
+
+end Test_List_of_List;
+
+

--- a/tests/real-annexes-execution/test_real_exec_02.aadl.out
+++ b/tests/real-annexes-execution/test_real_exec_02.aadl.out
@@ -151,22 +151,22 @@ Evaluating theorem set_declaration_is_passing_through
 
  * Iterate for variable: rma.erc32_node_a_task_1
 Content of set accessor_flows (test_real_exec_02.aadl:251:21) is 
-anonymous end to end flow :4020 end to end flow spec 
+anonymous end to end flow :4028 end to end flow spec 
  => Result: TRUE
 
  * Iterate for variable: rma.erc32_node_a_task_2
 Content of set accessor_flows (test_real_exec_02.aadl:251:21) is 
-anonymous end to end flow :4020 end to end flow spec 
+anonymous end to end flow :4028 end to end flow spec 
  => Result: TRUE
 
  * Iterate for variable: rma.erc32_node_a_task_12
 Content of set accessor_flows (test_real_exec_02.aadl:251:21) is 
-anonymous end to end flow :4021 end to end flow spec 
+anonymous end to end flow :4029 end to end flow spec 
  => Result: TRUE
 
  * Iterate for variable: rma.erc32_node_a_task_22
 Content of set accessor_flows (test_real_exec_02.aadl:251:21) is 
-anonymous end to end flow :4021 end to end flow spec 
+anonymous end to end flow :4029 end to end flow spec 
  => Result: TRUE
 
 theorem set_declaration_is_passing_through is: TRUE


### PR DESCRIPTION
This pull request enables the support for the use of nested lists in property values.
As suggested in Issue #282, the implementation is based on the idea to change `Property_List_Value` from `List_Id` to `Node_Id`.

A few things to note and check when reviewing the pull request are:

1. To minimize the impact on the existing code base, I keep `Multi_Value` and `Expanded_Multi_Value` as `List_Id` so that the existing handling for the property values with just a single-layer list is not impacted. The second and above layer nested lists, if existed, will be stored as `K_Property_List_Value` nodes in their previous layer's list nodes as intended.

2. The support for nested lists is also implemented in the `aadl` backend which benefits the test (`/tests/github/issue_282/test.aadl`) for this pull request.

3. The output for the test `tests/real-annexes-execution/test_real_exec_02.aadl` is revised based on my understanding that the correction is necessary and the difference is due to the change for the structure of `Property_List_Value`. It would be appreciated if you can verify this test output in particular.
