### PR TITLE
Fix a bug that fails to initialize a variable

### DIFF
--- a/src/core/model/ocarina-analyzer-aadl-semantics.adb
+++ b/src/core/model/ocarina-analyzer-aadl-semantics.adb
@@ -2682,7 +2682,7 @@ package body Ocarina.Analyzer.AADL.Semantics is
 
       List_Node            : Node_Id;
       Types_Are_Compatible : Boolean;
-      Success              : Boolean;
+      Success              : Boolean := True;
    begin
 
       List_Node :=


### PR DESCRIPTION
The uninitialized variable `Success` leads to a failure when analyzing the nested lists in property values.
This patch fixes the initialization as it is supposed to be.

Note that this patch is related to the feature stated in #282.