### PR TITLE
Add NVIDIA to copyright headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,10 @@ Current maintainer is
 
 Contributors
 
+Support of nested lists, contributed by NVIDIA
+
+- Chien-Ying Chen (CY Chen)
+
 LNT Back-end, contributed by ENIS
 
 - Hana Mkaouar

--- a/src/backends/aadl_pp/ocarina-be_aadl-properties.adb
+++ b/src/backends/aadl_pp/ocarina-be_aadl-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2008-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/core/instance/ocarina-instances-processor-properties.adb
+++ b/src/core/instance/ocarina-instances-processor-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2005-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/core/instance/ocarina-instances-properties.adb
+++ b/src/core/instance/ocarina-instances-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2005-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/core/model/ocarina-analyzer-aadl-semantics.adb
+++ b/src/core/model/ocarina-analyzer-aadl-semantics.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --                  Copyright (C) 2009 Telecom ParisTech,                   --
---                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/core/model/ocarina-processor-properties.adb
+++ b/src/core/model/ocarina-processor-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2005-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/core/tree/ocarina-me_aadl-aadl_tree-entities-properties.adb
+++ b/src/core/tree/ocarina-me_aadl-aadl_tree-entities-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2008-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --

--- a/src/frontends/aadl/ocarina-fe_aadl-parser-properties.adb
+++ b/src/frontends/aadl/ocarina-fe_aadl-parser-properties.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2008-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2021 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --


### PR DESCRIPTION
This commit adds NVIDIA to the copyright headers in the files where NVIDIA has had reasonable contributions in the last few commits.