### PR TITLE
Enable testing and add support of various property types for aadl_xml

### DIFF
--- a/resources/runtime/aadl_xml/aadl.xsd
+++ b/resources/runtime/aadl_xml/aadl.xsd
@@ -184,21 +184,33 @@
   
   <xs:element name='property'>
     <xs:complexType>
-      <xs:sequence minOccurs='1' maxOccurs='unbounded'>
-	<xs:element ref='property_value'/>
+      <xs:sequence>
+        <xs:element name='property_value' type="property_expression"/>
       </xs:sequence>
       <xs:attribute name='name' type="xs:string" use='required'/>
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="property_value">
+  <xs:complexType name='property_expression'>
+    <xs:choice minOccurs="1" maxOccurs="1">
+      <xs:element name="classifier" type="classifier_prop"/>
+      <xs:element name="reference" type="reference_prop"/>
+      <xs:element name="unit" type="unit_prop"/>
+      <xs:element name="value" type="value_prop"/>
+      <xs:element name="range" type="range_prop"/>
+      <xs:element ref="list"/>
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:element name='list'>
     <xs:complexType>
-      <xs:choice>
-	<xs:element name="classifier" type="classifier_prop"/>
-	<xs:element name="reference" type="reference_prop"/>
-	<xs:element name="unit" type="unit_prop"/>
-	<xs:element name="value" type="value_prop"/>
-	<xs:element name="range" type="range_prop"/>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="classifier" type="classifier_prop"/>
+        <xs:element name="reference" type="reference_prop"/>
+        <xs:element name="unit" type="unit_prop"/>
+        <xs:element name="value" type="value_prop"/>
+        <xs:element name="range" type="range_prop"/>
+        <xs:element ref="list"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>

--- a/resources/runtime/aadl_xml/aadl.xsd
+++ b/resources/runtime/aadl_xml/aadl.xsd
@@ -195,9 +195,11 @@
     <xs:choice minOccurs="1" maxOccurs="1">
       <xs:element name="classifier" type="classifier_prop"/>
       <xs:element name="reference" type="reference_prop"/>
-      <xs:element name="unit" type="unit_prop"/>
-      <xs:element name="value" type="value_prop"/>
+      <xs:element name="enumeration" type="enumeration_prop"/>
+      <xs:element name="number" type="unit_prop"/>
       <xs:element name="range" type="range_prop"/>
+      <xs:element name="string" type="string_prop"/>
+      <xs:element ref="record"/>
       <xs:element ref="list"/>
     </xs:choice>
   </xs:complexType>
@@ -207,34 +209,56 @@
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="classifier" type="classifier_prop"/>
         <xs:element name="reference" type="reference_prop"/>
-        <xs:element name="unit" type="unit_prop"/>
-        <xs:element name="value" type="value_prop"/>
+        <xs:element name="enumeration" type="enumeration_prop"/>
+        <xs:element name="number" type="unit_prop"/>
         <xs:element name="range" type="range_prop"/>
+        <xs:element name="string" type="string_prop"/>
+        <xs:element ref="record"/>
         <xs:element ref="list"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>
 
+  <xs:element name='record'>
+    <xs:complexType>
+      <xs:sequence minOccurs='1' maxOccurs='unbounded'>
+        <xs:element name='record_field'>
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:extension base="property_expression">
+                <xs:attribute name='name' type="xs:string" use='required'/>
+              </xs:extension>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
   <xs:complexType name='classifier_prop'>
-    <xs:attribute name='name' type="xs:string" use='required'/>
+    <xs:attribute name='value' type="xs:string" use='required'/>
   </xs:complexType>
 
   <xs:complexType name='unit_prop'>
-    <xs:attribute name='value' type="xs:string" use='required'/>
-    <xs:attribute name='unit' type="xs:string" use='required'/>
-  </xs:complexType>
-
-  <xs:complexType name='range_prop'>
-    <xs:attribute name='value_low' type="xs:string" use='required'/>
-    <xs:attribute name='value_high' type="xs:string" use='required'/>
+    <xs:attribute name='value' type="xs:decimal" use='required'/>
     <xs:attribute name='unit' type="xs:string" use='optional'/>
   </xs:complexType>
 
-  <xs:complexType name='value_prop'>
+  <xs:complexType name='range_prop'>
+    <xs:attribute name='value_low' type="xs:decimal" use='required'/>
+    <xs:attribute name='value_high' type="xs:decimal" use='required'/>
+    <xs:attribute name='unit' type="xs:string" use='optional'/>
+  </xs:complexType>
+
+  <xs:complexType name='string_prop'>
     <xs:attribute name='value' type="xs:string" use='required'/>
   </xs:complexType>
 
   <xs:complexType name='reference_prop'>
+    <xs:attribute name='value' type="xs:string" use='required'/>
+  </xs:complexType>
+
+  <xs:complexType name='enumeration_prop'>
     <xs:attribute name='value' type="xs:string" use='required'/>
   </xs:complexType>
 

--- a/tests/MANIFEST
+++ b/tests/MANIFEST
@@ -331,6 +331,7 @@ tests/github/issue_179/t.aadl
 tests/github/issue_270/test_modes.aadl
 tests/github/issue_282/test.aadl
 tests/github/issue_287/test_aadl_xml.aadl
+tests/github/issue_287/test_lists.aadl
 
 tests/root_system/test.aadl
 

--- a/tests/MANIFEST
+++ b/tests/MANIFEST
@@ -332,6 +332,7 @@ tests/github/issue_270/test_modes.aadl
 tests/github/issue_282/test.aadl
 tests/github/issue_287/test_aadl_xml.aadl
 tests/github/issue_287/test_lists.aadl
+tests/github/issue_287/test_property_terms.aadl
 
 tests/root_system/test.aadl
 

--- a/tests/MANIFEST
+++ b/tests/MANIFEST
@@ -330,6 +330,7 @@ tests/github/issue_177/test.aadl
 tests/github/issue_179/t.aadl
 tests/github/issue_270/test_modes.aadl
 tests/github/issue_282/test.aadl
+tests/github/issue_287/test_aadl_xml.aadl
 
 tests/root_system/test.aadl
 

--- a/tests/github/issue_287/MANIFEST
+++ b/tests/github/issue_287/MANIFEST
@@ -1,0 +1,2 @@
+AADL_VERSION=-aadlv2
+OCARINA_FLAGS=-g aadl_xml

--- a/tests/github/issue_287/test_aadl_xml.aadl
+++ b/tests/github/issue_287/test_aadl_xml.aadl
@@ -1,0 +1,10 @@
+package Test_Aadl_Xml_Output
+public
+
+    system main
+    end main;
+
+    system implementation main.impl
+    end main.impl;
+
+end Test_Aadl_Xml_Output;

--- a/tests/github/issue_287/test_aadl_xml.aadl.out
+++ b/tests/github/issue_287/test_aadl_xml.aadl.out
@@ -1,0 +1,11 @@
+<aadl_xml root_system="main.impl">
+ <components>
+   <component category="system" identifier="main.impl">
+     <classifier>
+       main.impl     </classifier>
+     <features/>
+     <subcomponents/>
+     <properties/>
+   </component>
+ </components>
+</aadl_xml>

--- a/tests/github/issue_287/test_lists.aadl
+++ b/tests/github/issue_287/test_lists.aadl
@@ -1,0 +1,21 @@
+property set Test_List_of_List_Properties is
+  a_list_of_list_property: list of list of aadlinteger applies to (system);
+  a_list_of_list_of_list_property: list of list of list of aadlinteger applies to (system);
+  a_list_of_list_of_list_of_list_property: list of list of list of list of aadlinteger applies to (system);
+end Test_List_of_List_Properties;
+
+package Test_List_of_List
+public
+    with Test_List_of_List_Properties;
+
+    system main
+    end main;
+
+    system implementation main.impl
+        properties
+            Test_List_of_List_Properties::a_list_of_list_property => ((1,2), (3,4));
+            Test_List_of_List_Properties::a_list_of_list_of_list_property => (((1,2),(3,4)),((5,6),(7,8)));
+            Test_List_of_List_Properties::a_list_of_list_of_list_of_list_property => ((((1,2)),((3,4))),(((5,6)),((7,8))));
+    end main.impl;
+
+end Test_List_of_List;

--- a/tests/github/issue_287/test_lists.aadl.out
+++ b/tests/github/issue_287/test_lists.aadl.out
@@ -1,0 +1,86 @@
+<aadl_xml root_system="main.impl">
+ <components>
+   <component category="system" identifier="main.impl">
+     <classifier>
+       main.impl     </classifier>
+     <features/>
+     <subcomponents/>
+     <properties>
+       <property name="Test_List_of_List_Properties::a_list_of_list_of_list_of_list_property">
+         <property_value>
+           <list>
+             <list>
+               <list>
+                 <list>
+                   <value value="1"/>
+                   <value value="2"/>
+                 </list>
+               </list>
+               <list>
+                 <list>
+                   <value value="3"/>
+                   <value value="4"/>
+                 </list>
+               </list>
+             </list>
+             <list>
+               <list>
+                 <list>
+                   <value value="5"/>
+                   <value value="6"/>
+                 </list>
+               </list>
+               <list>
+                 <list>
+                   <value value="7"/>
+                   <value value="8"/>
+                 </list>
+               </list>
+             </list>
+           </list>
+         </property_value>
+       </property>
+       <property name="Test_List_of_List_Properties::a_list_of_list_of_list_property">
+         <property_value>
+           <list>
+             <list>
+               <list>
+                 <value value="1"/>
+                 <value value="2"/>
+               </list>
+               <list>
+                 <value value="3"/>
+                 <value value="4"/>
+               </list>
+             </list>
+             <list>
+               <list>
+                 <value value="5"/>
+                 <value value="6"/>
+               </list>
+               <list>
+                 <value value="7"/>
+                 <value value="8"/>
+               </list>
+             </list>
+           </list>
+         </property_value>
+       </property>
+       <property name="Test_List_of_List_Properties::a_list_of_list_property">
+         <property_value>
+           <list>
+             <list>
+               <value value="1"/>
+               <value value="2"/>
+             </list>
+             <list>
+               <value value="3"/>
+               <value value="4"/>
+             </list>
+           </list>
+         </property_value>
+       </property>
+     </properties>
+   </component>
+ </components>
+</aadl_xml>

--- a/tests/github/issue_287/test_lists.aadl.out
+++ b/tests/github/issue_287/test_lists.aadl.out
@@ -12,28 +12,28 @@
              <list>
                <list>
                  <list>
-                   <value value="1"/>
-                   <value value="2"/>
+                   <number value="1"/>
+                   <number value="2"/>
                  </list>
                </list>
                <list>
                  <list>
-                   <value value="3"/>
-                   <value value="4"/>
+                   <number value="3"/>
+                   <number value="4"/>
                  </list>
                </list>
              </list>
              <list>
                <list>
                  <list>
-                   <value value="5"/>
-                   <value value="6"/>
+                   <number value="5"/>
+                   <number value="6"/>
                  </list>
                </list>
                <list>
                  <list>
-                   <value value="7"/>
-                   <value value="8"/>
+                   <number value="7"/>
+                   <number value="8"/>
                  </list>
                </list>
              </list>
@@ -45,22 +45,22 @@
            <list>
              <list>
                <list>
-                 <value value="1"/>
-                 <value value="2"/>
+                 <number value="1"/>
+                 <number value="2"/>
                </list>
                <list>
-                 <value value="3"/>
-                 <value value="4"/>
+                 <number value="3"/>
+                 <number value="4"/>
                </list>
              </list>
              <list>
                <list>
-                 <value value="5"/>
-                 <value value="6"/>
+                 <number value="5"/>
+                 <number value="6"/>
                </list>
                <list>
-                 <value value="7"/>
-                 <value value="8"/>
+                 <number value="7"/>
+                 <number value="8"/>
                </list>
              </list>
            </list>
@@ -70,12 +70,12 @@
          <property_value>
            <list>
              <list>
-               <value value="1"/>
-               <value value="2"/>
+               <number value="1"/>
+               <number value="2"/>
              </list>
              <list>
-               <value value="3"/>
-               <value value="4"/>
+               <number value="3"/>
+               <number value="4"/>
              </list>
            </list>
          </property_value>

--- a/tests/github/issue_287/test_property_terms.aadl
+++ b/tests/github/issue_287/test_property_terms.aadl
@@ -1,0 +1,77 @@
+property set Test_Properties is
+  an_integer_property: aadlinteger applies to (all);
+  a_negative_integer_property: aadlinteger applies to (all);
+  an_integer_unit_property: aadlinteger units (ms) applies to (all);
+  an_integer_range_property: range of aadlinteger applies to (all);
+
+  a_real_property: aadlreal applies to (all);
+  a_negative_real_property: aadlreal applies to (all);
+  a_real_unit_property: aadlreal units (ns) applies to (all);
+  a_real_range_property: range of aadlreal applies to (all);
+
+  a_string_property: aadlstring applies to (all);
+
+  a_boolean_property: aadlboolean applies to (all);
+
+  a_list_of_list_property: list of list of aadlinteger applies to (all);
+
+  a_reference_property: reference (system, device) applies to (all);
+
+  a_classifier_property: classifier (system, device) applies to (all);
+
+  an_enumeration_type: type enumeration (enum1, enum2, enum3);
+  an_enumeration_property: Test_Properties::an_enumeration_type applies to (all);
+
+  a_record_property: record (
+    an_integer_field: aadlinteger;
+    a_string_field: aadlstring;
+    a_real_range_field: range of aadlreal;
+  ) applies to (all);
+
+end Test_Properties;
+
+package Test
+public
+  with Test_Properties;
+
+  system main
+  end main;
+
+  system implementation main.impl
+    subcomponents
+      subcomp_subdevice: device subdevice.impl;
+    properties
+
+      Test_Properties::an_integer_property => 10;
+      Test_Properties::a_negative_integer_property => -10;
+      Test_Properties::an_integer_unit_property => 10 ms;
+      Test_Properties::an_integer_range_property => 5 .. 10;
+
+      Test_Properties::a_real_property => 10.0;
+      Test_Properties::a_negative_real_property => -10.0;
+      Test_Properties::a_real_unit_property => 10 ns;
+      Test_Properties::a_real_range_property => 5.0 .. 10.0;
+
+      Test_Properties::a_string_property => "test string";
+
+      Test_Properties::a_boolean_property => true;
+
+      Test_Properties::a_list_of_list_property => ((1,2), (3,4));
+
+      Test_Properties::a_reference_property => reference (subcomp_subdevice);
+
+      Test_Properties::a_classifier_property => classifier (subdevice);
+
+      Test_Properties::an_enumeration_property => enum2;
+
+      Test_Properties::a_record_property => [an_integer_field => 10; a_string_field => "test string"; a_real_range_field => 5.0 .. 10.0];
+
+  end main.impl;
+
+  device subdevice
+  end subdevice;
+
+  device implementation subdevice.impl
+  end subdevice.impl;
+
+end Test;

--- a/tests/github/issue_287/test_property_terms.aadl.out
+++ b/tests/github/issue_287/test_property_terms.aadl.out
@@ -1,0 +1,114 @@
+<aadl_xml root_system="main.impl">
+ <components>
+   <component category="system" identifier="main.impl">
+     <classifier>
+       main.impl     </classifier>
+     <features/>
+     <subcomponents>
+       <component category="device" identifier="subcomp_subdevice">
+         <classifier>
+           subdevice.impl         </classifier>
+         <features/>
+         <subcomponents/>
+         <properties/>
+       </component>
+     </subcomponents>
+     <properties>
+       <property name="Test_Properties::a_record_property">
+         <property_value>
+           <record>
+             <record_field name="an_integer_field">
+               <number value="10"/>
+             </record_field>
+             <record_field name="a_string_field">
+               <string value="test string"/>
+             </record_field>
+             <record_field name="a_real_range_field">
+               <range value_low="5.0" value_high="10.0"/>
+             </record_field>
+           </record>
+         </property_value>
+       </property>
+       <property name="Test_Properties::an_enumeration_property">
+         <property_value>
+           <enumeration value="enum2"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_classifier_property">
+         <property_value>
+           <classifier value="subdevice"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_reference_property">
+         <property_value>
+           <reference value="subcomp_subdevice"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_list_of_list_property">
+         <property_value>
+           <list>
+             <list>
+               <number value="1"/>
+               <number value="2"/>
+             </list>
+             <list>
+               <number value="3"/>
+               <number value="4"/>
+             </list>
+           </list>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_boolean_property">
+         <property_value>
+           <string value="true"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_string_property">
+         <property_value>
+           <string value="test string"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_real_range_property">
+         <property_value>
+           <range value_low="5.0" value_high="10.0"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_real_unit_property">
+         <property_value>
+           <number value="10" unit="ns"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_negative_real_property">
+         <property_value>
+           <number value="-10.0"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_real_property">
+         <property_value>
+           <number value="10.0"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::an_integer_range_property">
+         <property_value>
+           <range value_low="5" value_high="10"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::an_integer_unit_property">
+         <property_value>
+           <number value="10" unit="ms"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::a_negative_integer_property">
+         <property_value>
+           <number value="-10"/>
+         </property_value>
+       </property>
+       <property name="Test_Properties::an_integer_property">
+         <property_value>
+           <number value="10"/>
+         </property_value>
+       </property>
+     </properties>
+   </component>
+ </components>
+</aadl_xml>


### PR DESCRIPTION
This PL contains two major changes:
#### 1. Enable testing for aadl_xml
The current implementation of the aadl_xml backend takes the command line option "-o" as the output directory and lets the XML generator determines the output XML file name based on the given AADL model's name.

This design doesn't fit into the current auto test scheme in which the output file name should be configurable by using the "-o" option.

This commit adds support of accepting the "-o" option as either an output directory or an output file name. In the case that a directory is specified or the option "-o" is not assigned, the output file name is determined by the XML generator as it is originally implemented. Otherwise, the output XML is stored in the file with the given file name.

As a result, this change enables testing the aadl_xml backend under the current test environment, which is beneficial to latter commits.

#### 2. Add support of various types in property values
The second part is for what have been raised in #287.
- Add support of nested lists
- Add support of the "record" type
- Add support of the "classifier" type
- Use an XML element "number" to represent a aadlinteger/aadlreal
  property value with/without an unit
- Use an XML element "enumeration" to represent an "enumeration"
  property value
- Use an XML element "string" to represent a aadlstring property value
