### PR TITLE
Add port connections in aadl_xml

### DIFF
--- a/resources/runtime/aadl_xml/aadl.xsd
+++ b/resources/runtime/aadl_xml/aadl.xsd
@@ -161,14 +161,14 @@
   
   <xs:element name='src'>
     <xs:complexType>
-      <xs:attribute name='component' type="xs:string" use='required'/>
+      <xs:attribute name='component' type="xs:string" use='optional'/>
       <xs:attribute name='feature' type="xs:string" use='required'/>
     </xs:complexType>
   </xs:element>
   
   <xs:element name='dst'>
     <xs:complexType>
-      <xs:attribute name='component' type="xs:string" use='required'/>
+      <xs:attribute name='component' type="xs:string" use='optional'/>
       <xs:attribute name='feature' type="xs:string" use='required'/>
     </xs:complexType>
   </xs:element>

--- a/tests/MANIFEST
+++ b/tests/MANIFEST
@@ -333,6 +333,7 @@ tests/github/issue_282/test.aadl
 tests/github/issue_287/test_aadl_xml.aadl
 tests/github/issue_287/test_lists.aadl
 tests/github/issue_287/test_property_terms.aadl
+tests/github/issue_287/test_aadl_xml_connections.aadl
 
 tests/root_system/test.aadl
 

--- a/tests/github/issue_287/test_aadl_xml_connections.aadl
+++ b/tests/github/issue_287/test_aadl_xml_connections.aadl
@@ -12,7 +12,7 @@ public
             p2: process dummy_process.impl;
 
         connections
-            conn1: port p1.out_port -> p2.in_port;
+            conn1: port p1.out_port -> p2.in_port {Timing => Immediate; Latency => 1ms .. 10ms;};
     end main.impl;
 
     process dummy_process
@@ -28,7 +28,7 @@ public
 
         connections
             conn1: port in_port -> t1.in_port;
-            conn2: port t1.out_port -> t2.in_port;
+            conn2: port t1.out_port -> t2.in_port {Timing => Delayed;};
             conn3: port t2.out_port -> out_port;
     end dummy_process.impl;
 

--- a/tests/github/issue_287/test_aadl_xml_connections.aadl
+++ b/tests/github/issue_287/test_aadl_xml_connections.aadl
@@ -1,0 +1,44 @@
+package Test_Aadl_Xml_Connections
+public
+
+    data dummy_data end dummy_data;
+
+    system main
+    end main;
+
+    system implementation main.impl
+        subcomponents
+            p1: process dummy_process.impl;
+            p2: process dummy_process.impl;
+
+        connections
+            conn1: port p1.out_port -> p2.in_port;
+    end main.impl;
+
+    process dummy_process
+        features
+            in_port: in data port dummy_data;
+            out_port: out data port dummy_data;
+    end dummy_process;
+
+    process implementation dummy_process.impl
+        subcomponents
+            t1: thread dummy_thread.impl;
+            t2: thread dummy_thread.impl;
+
+        connections
+            conn1: port in_port -> t1.in_port;
+            conn2: port t1.out_port -> t2.in_port;
+            conn3: port t2.out_port -> out_port;
+    end dummy_process.impl;
+
+    thread dummy_thread
+        features
+            in_port: in data port dummy_data;
+            out_port: out data port dummy_data;
+    end dummy_thread;
+
+    thread implementation dummy_thread.impl
+    end dummy_thread.impl;
+
+end Test_Aadl_Xml_Connections;

--- a/tests/github/issue_287/test_aadl_xml_connections.aadl.out
+++ b/tests/github/issue_287/test_aadl_xml_connections.aadl.out
@@ -1,0 +1,168 @@
+<aadl_xml root_system="main.impl">
+ <components>
+   <component category="system" identifier="main.impl">
+     <classifier>
+       main.impl     </classifier>
+     <features/>
+     <subcomponents>
+       <component category="process" identifier="p1">
+         <classifier>
+           dummy_process.impl         </classifier>
+         <features>
+           <feature identifier="in_port">
+             <direction kind="in"/>
+             <type kind="data"/>
+             <classifier>
+               dummy_data             </classifier>
+           </feature>
+           <feature identifier="out_port">
+             <direction kind="out"/>
+             <type kind="data"/>
+             <classifier>
+               dummy_data             </classifier>
+           </feature>
+         </features>
+         <subcomponents>
+           <component category="thread" identifier="t1">
+             <classifier>
+               dummy_thread.impl             </classifier>
+             <features>
+               <feature identifier="in_port">
+                 <direction kind="in"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+               <feature identifier="out_port">
+                 <direction kind="out"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+             </features>
+             <subcomponents/>
+             <properties/>
+           </component>
+           <component category="thread" identifier="t2">
+             <classifier>
+               dummy_thread.impl             </classifier>
+             <features>
+               <feature identifier="in_port">
+                 <direction kind="in"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+               <feature identifier="out_port">
+                 <direction kind="out"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+             </features>
+             <subcomponents/>
+             <properties/>
+           </component>
+         </subcomponents>
+         <properties/>
+         <connections>
+           <connection name="conn1">
+             <src feature="in_port"/>
+             <dst component="t1" feature="in_port"/>
+           </connection>
+           <connection name="conn2">
+             <src component="t1" feature="out_port"/>
+             <dst component="t2" feature="in_port"/>
+           </connection>
+           <connection name="conn3">
+             <src component="t2" feature="out_port"/>
+             <dst feature="out_port"/>
+           </connection>
+         </connections>
+       </component>
+       <component category="process" identifier="p2">
+         <classifier>
+           dummy_process.impl         </classifier>
+         <features>
+           <feature identifier="in_port">
+             <direction kind="in"/>
+             <type kind="data"/>
+             <classifier>
+               dummy_data             </classifier>
+           </feature>
+           <feature identifier="out_port">
+             <direction kind="out"/>
+             <type kind="data"/>
+             <classifier>
+               dummy_data             </classifier>
+           </feature>
+         </features>
+         <subcomponents>
+           <component category="thread" identifier="t1">
+             <classifier>
+               dummy_thread.impl             </classifier>
+             <features>
+               <feature identifier="in_port">
+                 <direction kind="in"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+               <feature identifier="out_port">
+                 <direction kind="out"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+             </features>
+             <subcomponents/>
+             <properties/>
+           </component>
+           <component category="thread" identifier="t2">
+             <classifier>
+               dummy_thread.impl             </classifier>
+             <features>
+               <feature identifier="in_port">
+                 <direction kind="in"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+               <feature identifier="out_port">
+                 <direction kind="out"/>
+                 <type kind="data"/>
+                 <classifier>
+                   dummy_data                 </classifier>
+               </feature>
+             </features>
+             <subcomponents/>
+             <properties/>
+           </component>
+         </subcomponents>
+         <properties/>
+         <connections>
+           <connection name="conn1">
+             <src feature="in_port"/>
+             <dst component="t1" feature="in_port"/>
+           </connection>
+           <connection name="conn2">
+             <src component="t1" feature="out_port"/>
+             <dst component="t2" feature="in_port"/>
+           </connection>
+           <connection name="conn3">
+             <src component="t2" feature="out_port"/>
+             <dst feature="out_port"/>
+           </connection>
+         </connections>
+       </component>
+     </subcomponents>
+     <properties/>
+     <connections>
+       <connection name="conn1">
+         <src component="p1" feature="out_port"/>
+         <dst component="p2" feature="in_port"/>
+       </connection>
+     </connections>
+   </component>
+ </components>
+</aadl_xml>

--- a/tests/github/issue_287/test_aadl_xml_connections.aadl.out
+++ b/tests/github/issue_287/test_aadl_xml_connections.aadl.out
@@ -69,14 +69,23 @@
            <connection name="conn1">
              <src feature="in_port"/>
              <dst component="t1" feature="in_port"/>
+             <properties/>
            </connection>
            <connection name="conn2">
              <src component="t1" feature="out_port"/>
              <dst component="t2" feature="in_port"/>
+             <properties>
+               <property name="Timing">
+                 <property_value>
+                   <enumeration value="Delayed"/>
+                 </property_value>
+               </property>
+             </properties>
            </connection>
            <connection name="conn3">
              <src component="t2" feature="out_port"/>
              <dst feature="out_port"/>
+             <properties/>
            </connection>
          </connections>
        </component>
@@ -144,14 +153,23 @@
            <connection name="conn1">
              <src feature="in_port"/>
              <dst component="t1" feature="in_port"/>
+             <properties/>
            </connection>
            <connection name="conn2">
              <src component="t1" feature="out_port"/>
              <dst component="t2" feature="in_port"/>
+             <properties>
+               <property name="Timing">
+                 <property_value>
+                   <enumeration value="Delayed"/>
+                 </property_value>
+               </property>
+             </properties>
            </connection>
            <connection name="conn3">
              <src component="t2" feature="out_port"/>
              <dst feature="out_port"/>
+             <properties/>
            </connection>
          </connections>
        </component>
@@ -161,6 +179,18 @@
        <connection name="conn1">
          <src component="p1" feature="out_port"/>
          <dst component="p2" feature="in_port"/>
+         <properties>
+           <property name="Latency">
+             <property_value>
+               <range value_low="1" value_high="10" unit="ms"/>
+             </property_value>
+           </property>
+           <property name="Timing">
+             <property_value>
+               <enumeration value="Immediate"/>
+             </property_value>
+           </property>
+         </properties>
        </connection>
      </connections>
    </component>


### PR DESCRIPTION
This PL (related to #287) adds connection and property elements for port connections in the XML generated by the backend aadl_xml.

Based on discussion in #287, a connection's entity (i.e., either source and destination) contains attributes `component` and `feature` that represent a connection of either of the forms:

- `feature` which represents a port's identifier when the entity is a port of the current component. `component` is empty (optional) in this case.

- `component.feature` where `component` is a subcomponent's identifier when the connection entity is a port of a subcomponent.
