### PR TITLE
Support specifying output file name in cheddar backend

### DIFF
--- a/src/backends/cheddar/ocarina-backends-cheddar.adb
+++ b/src/backends/cheddar/ocarina-backends-cheddar.adb
@@ -6,7 +6,8 @@
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---         Copyright (C) 2010-2019 ESA & ISAE, 2019-2020 OpenAADL           --
+--                   Copyright (C) 2010-2019 ESA & ISAE,                    --
+--                     2019-2021 OpenAADL, 2021 NVIDIA                      --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -29,6 +30,8 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
+with GNAT.OS_Lib;
+
 with Ocarina.Instances;
 with Ocarina.Backends.Expander;
 with Ocarina.Backends.Messages;
@@ -37,6 +40,9 @@ with Ocarina.Backends.Utils;
 with Ocarina.Backends.XML_Tree.Nodes;
 with Ocarina.Backends.XML_Tree.Nutils;
 with Ocarina.Backends.XML_Tree.Generator;
+with Ocarina.Namet;
+with Ocarina.Output;
+with Ocarina.Options;
 
 package body Ocarina.Backends.Cheddar is
 
@@ -58,8 +64,12 @@ package body Ocarina.Backends.Cheddar is
    --------------
 
    procedure Generate (AADL_Root : Node_Id) is
-      Instance_Root : Node_Id;
+      use GNAT.OS_Lib;
+      use Ocarina.Namet;
+      use Ocarina.Output;
+      use Ocarina.Options;
 
+      Instance_Root : Node_Id;
    begin
       Instance_Root := Instantiate_Model (AADL_Root);
 
@@ -79,15 +89,26 @@ package body Ocarina.Backends.Cheddar is
          Display_Error ("XML generation failed", Fatal => True);
       end if;
 
-      Create_Directory (Generated_Sources_Directory);
+      if Output_Filename /= No_Name and then
+         not Is_Directory (Get_Name_String (Output_Filename))
+      then
+         --  Create the output file based on the given file name
 
-      Enter_Directory (Generated_Sources_Directory);
+         Set_Output
+            (Create_File
+               (Get_Name_String (Output_Filename),
+               Binary));
+         XML_Tree.Generator.Generate (XML_Root);
+      else
+         --  Enter to the given directory and let the XML generator
+         --  determine the output file name
 
-      --  Create the XML file
+         Enter_Directory (Generated_Sources_Directory);
 
-      XML_Tree.Generator.Generate (XML_Root);
+         XML_Tree.Generator.Generate (XML_Root);
 
-      Leave_Directory;
+         Leave_Directory;
+      end if;
    end Generate;
 
    ----------

--- a/tests/MANIFEST
+++ b/tests/MANIFEST
@@ -334,6 +334,7 @@ tests/github/issue_287/test_aadl_xml.aadl
 tests/github/issue_287/test_lists.aadl
 tests/github/issue_287/test_property_terms.aadl
 tests/github/issue_287/test_aadl_xml_connections.aadl
+tests/github/issue_288/test_cheddar.aadl
 
 tests/root_system/test.aadl
 

--- a/tests/github/issue_288/MANIFEST
+++ b/tests/github/issue_288/MANIFEST
@@ -1,0 +1,2 @@
+AADL_VERSION=-aadlv2
+OCARINA_FLAGS=-f -g cheddar

--- a/tests/github/issue_288/test_cheddar.aadl
+++ b/tests/github/issue_288/test_cheddar.aadl
@@ -1,0 +1,62 @@
+package Test_Cheddar
+public
+
+    with Cheddar_Properties;
+
+    -- Top level component of the whole system
+    system deployment
+    end deployment;
+
+    system implementation deployment.impl
+        subcomponents
+            cpu: processor main_processor.impl;
+            p1: process dummy_process.impl;
+
+        properties
+            Actual_Processor_Binding => (reference (cpu)) applies to p1;
+    end deployment.impl;
+
+    processor main_processor
+    end main_processor;
+
+    processor implementation main_processor.impl
+        properties
+            Scheduling_Protocol => (RMS);
+            Preemptive_Scheduler => true;
+            Priority_Range => 0 .. 255;
+    end main_processor.impl;
+
+    process dummy_process
+    end dummy_process;
+
+    process implementation dummy_process.impl
+        subcomponents
+            t1: thread task1.impl;
+            t2: thread task2.impl;
+    end dummy_process.impl;
+
+    thread task1
+    end task1;
+
+    thread implementation task1.impl
+        properties
+            Compute_Execution_time => 2ms .. 10ms;
+            Period => 20ms;
+            Deadline => 20ms;
+            Dispatch_Protocol => Periodic;
+            Cheddar_Properties::Fixed_Priority => 1;
+    end task1.impl;
+
+    thread task2
+    end task2;
+
+    thread implementation task2.impl
+        properties
+            Compute_Execution_time => 5ms .. 15ms;
+            Period => 50ms;
+            Deadline => 50ms;
+            Dispatch_Protocol => Periodic;
+            Cheddar_Properties::Fixed_Priority => 2;
+    end task2.impl;
+
+end Test_Cheddar;

--- a/tests/github/issue_288/test_cheddar.aadl.out
+++ b/tests/github/issue_288/test_cheddar.aadl.out
@@ -1,0 +1,171 @@
+<?xml version="1.0" standalone="yes"?>  
+<?xml-stylesheet type="text/xsl" href="cheddar_project.xsl"?>
+<!DOCTYPE cheddar [  
+<!ELEMENT name (#PCDATA) > 
+<!ELEMENT scheduler (#PCDATA) > 
+<!ELEMENT parameter (#PCDATA) > 
+<!ELEMENT context_switch_overhead (#PCDATA) > 
+<!ELEMENT network_link (#PCDATA) > 
+<!ELEMENT offset (#PCDATA) > 
+<!ELEMENT period (#PCDATA) > 
+<!ELEMENT capacity (#PCDATA) > 
+<!ELEMENT deadline (#PCDATA) > 
+<!ELEMENT context_switch_overhead (#PCDATA) > 
+<!ELEMENT start_time (#PCDATA) > 
+<!ELEMENT blocking_time (#PCDATA) > 
+<!ELEMENT policy (#PCDATA) > 
+<!ELEMENT priority (#PCDATA) > 
+<!ELEMENT criticality (#PCDATA) > 
+<!ELEMENT cpu_name (#PCDATA) > 
+<!ELEMENT address_space_name (#PCDATA) > 
+<!ELEMENT jitter (#PCDATA) > 
+<!ELEMENT seed (#PCDATA) > 
+<!ELEMENT predictable_seed (#PCDATA) > 
+<!ELEMENT activation_rule (#PCDATA) > 
+<!ELEMENT state (#PCDATA) > 
+<!ELEMENT protocol (#PCDATA) > 
+<!ELEMENT size (#PCDATA) > 
+<!ELEMENT qs (#PCDATA) > 
+<!ELEMENT time (#PCDATA) > 
+<!ELEMENT buffer_user (#PCDATA) >  
+<!ELEMENT resource_user (#PCDATA) >  
+<!ELEMENT event_analyzer (#PCDATA) >  
+<!ELEMENT type (#PCDATA) >  
+<!ELEMENT text_memory_size (#PCDATA) >  
+<!ELEMENT heap_memory_size (#PCDATA) >  
+<!ELEMENT stack_memory_size (#PCDATA) >  
+<!ELEMENT data_memory_size (#PCDATA) >  
+<!ELEMENT cheddar (processors, (address_spaces)?, (tasks)?, ((event_analyzers)?|(networks)?|(buffers)?|(resources)?|(messages)?),(dependencies)?  )  >   
+<!ELEMENT processors (processor)+ >  
+<!ELEMENT processor (name|scheduler|network_link) >  
+<!ELEMENT address_spaces (address_space)+ >  
+<!ELEMENT address_space (name|text_memory_size|data_memory_size|stack_memory_size|heap_memory_size|(scheduler)?) >  
+<!ELEMENT networks (network)+ >  
+<!ELEMENT network (name|type) >  
+<!ELEMENT tasks (task)+>  
+<!ELEMENT task (name|cpu_name|address_space_name|capacity|start_time|(context_switch_overhead)?|(stack_memory_size)?|(text_memory_size)?|(period)?|(deadline)?|(parameters)?|(offsets)?|(jitter)?|(policy)?|(criticality)?|(priority)?|(predictable_seed)?|(blocking_time)?|(seed)?
+|(activation_rule)?) >  
+<!ELEMENT offsets (offset)+ >  
+<!ELEMENT parameters (parameter)+ >  
+<!ELEMENT messages (message)+ >  
+<!ELEMENT message (name|size|(period)?|(deadline)?|(jitter)?) >  
+<!ELEMENT buffers (buffer)+ >  
+<!ELEMENT buffer (cpu_name|address_space_name|qs|name|size|(buffer_used_by)?) >  
+<!ELEMENT buffer_used_by (buffer_user)+ >  
+<!ELEMENT resources (resource)+ >  
+<!ELEMENT resource (cpu_name|address_space_name|name|protocol|(state)?|(resource_used_by)?) >  
+<!ELEMENT resource_used_by (resource_user)+ >  
+<!ELEMENT dependencies (dependency)+ >  
+<!ELEMENT event_analyzers (event_analyzer)+ >  
+<!ELEMENT dependency (#PCDATA)  >  
+<!ATTLIST scheduler 
+        quantum CDATA  "0"  
+        is_preemptive CDATA  "PREEMPTIVE"  
+        automaton_name CDATA  ""  
+        parametric_file_name CDATA "" >  
+<!ATTLIST event_analyzer  
+        parametric_file_name CDATA "" >  
+<!ATTLIST task  
+        task_type CDATA  "APERIODIC_TYPE"  
+        x CDATA "0"  
+        y CDATA "0" > 
+<!ATTLIST buffer  
+        x CDATA "0" 
+        y CDATA "0" > 
+<!ATTLIST message  
+        x CDATA "0" 
+        y CDATA "0" > 
+<!ATTLIST buffer_user 
+        buffer_role CDATA  "producer" >  
+<!ATTLIST dependency 
+        from_type CDATA "task" 
+        to_type CDATA "task" > 
+<!ATTLIST parameter 
+        parameter_type CDATA  "integer" >  
+] >  
+
+<cheddar>
+ <processors>
+   <processor>
+     <name>
+       cpu     </name>
+     <scheduler>
+       RATE_MONOTONIC_PROTOCOL     </scheduler>
+     <network_link>
+       No_Network     </network_link>
+   </processor>
+ </processors>
+ <address_spaces>
+   <address_space>
+     <name>
+       p1     </name>
+     <cpu_name>
+       cpu     </cpu_name>
+     <text_memory_size>
+       0     </text_memory_size>
+     <data_memory_size>
+       0     </data_memory_size>
+     <stack_memory_size>
+       0     </stack_memory_size>
+     <heap_memory_size>
+       0     </heap_memory_size>
+   </address_space>
+ </address_spaces>
+ <tasks>
+   <task task_type="PERIODIC_TYPE">
+     <cpu_name>
+       cpu     </cpu_name>
+     <address_space_name>
+       p1     </address_space_name>
+     <name>
+       p1_t1     </name>
+     <capacity>
+       10000     </capacity>
+     <start_time>
+       0     </start_time>
+     <deadline>
+       20000     </deadline>
+     <blocking_time>
+       0     </blocking_time>
+     <priority>
+       1     </priority>
+     <text_memory_size>
+       0     </text_memory_size>
+     <stack_memory_size>
+       0     </stack_memory_size>
+     <period>
+       20000     </period>
+     <jitter>
+       0     </jitter>
+   </task>
+   <task task_type="PERIODIC_TYPE">
+     <cpu_name>
+       cpu     </cpu_name>
+     <address_space_name>
+       p1     </address_space_name>
+     <name>
+       p1_t2     </name>
+     <capacity>
+       15000     </capacity>
+     <start_time>
+       0     </start_time>
+     <deadline>
+       50000     </deadline>
+     <blocking_time>
+       0     </blocking_time>
+     <priority>
+       2     </priority>
+     <text_memory_size>
+       0     </text_memory_size>
+     <stack_memory_size>
+       0     </stack_memory_size>
+     <period>
+       50000     </period>
+     <jitter>
+       0     </jitter>
+   </task>
+ </tasks>
+ <buffers/>
+ <resources/>
+ <dependencies/>
+</cheddar>


### PR DESCRIPTION
The current implementation of cheddar backend takes the command line option `-o` as the output directory and lets the XML generator determines the output XML file name based on the constructed XML tree.

This commit adds support of accepting the `-o` option as either an output directory or an output file name. In the case that a directory is specified or the option `-o` is not assigned, the output file name is determined by the XML generator as it was originally implemented. Otherwise, the output XML is stored in the file with the given file name.

This change also enables testing the cheddar backend under the current test environment.

This was partially mentioned in #288.