### PR TITLE
Add connection type in model instances and aadl_xml

### DIFF
--- a/resources/runtime/aadl_xml/aadl.xsd
+++ b/resources/runtime/aadl_xml/aadl.xsd
@@ -156,6 +156,26 @@
 	<xs:element ref='properties' minOccurs='0' maxOccurs='1'/>
       </xs:sequence>
       <xs:attribute name='name' type="xs:string" use='optional'/>
+      <xs:attribute name='type' use='optional'>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value='event_data'/>
+            <xs:enumeration value='data_delayed'/>
+            <xs:enumeration value='data'/>
+            <xs:enumeration value='event'/>
+            <xs:enumeration value='feature_group'/>
+            <xs:enumeration value='parameter'/>
+            <xs:enumeration value='access_bus'/>
+            <xs:enumeration value='access_data'/>
+            <xs:enumeration value='access_subprogram'/>
+            <xs:enumeration value='access_virtual_bus'/>
+            <xs:enumeration value='feature'/>
+            <xs:enumeration value='port_connection'/>
+            <xs:enumeration value='access_subprogram_group'/>
+            <xs:enumeration value='access'/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   

--- a/src/backends/aadl_xml/ocarina-backends-aadl_xml-main.adb
+++ b/src/backends/aadl_xml/ocarina-backends-aadl_xml-main.adb
@@ -346,6 +346,72 @@ package body Ocarina.Backends.AADL_XML.Main is
                   Make_Defining_Identifier (Display_Name (Identifier (F)))),
                XTN.Items (Connection_Node));
 
+            --  Connection type
+
+            if Present (Associated_Type (F)) then
+
+               declare
+                  Connection_Type : Ocarina.ME_AADL.Connection_Type;
+                  Type_String     : Name_Id;
+               begin
+                  Connection_Type := Get_Category_Of_Connection (F);
+
+                  --  AADL_V1
+                  if Connection_Type = CT_Event_Data then
+                     Type_String := Get_String_Name ("event_data");
+
+                  elsif Connection_Type = CT_Data_Delayed then
+                     Type_String := Get_String_Name ("data_delayed");
+
+                  --  AADL_V1 and AADL_V2
+                  elsif Connection_Type = CT_Data then
+                     Type_String := Get_String_Name ("data");
+
+                  elsif Connection_Type = CT_Event then
+                     Type_String := Get_String_Name ("event");
+
+                  elsif Connection_Type = CT_Feature_Group then
+                     Type_String := Get_String_Name ("feature_group");
+
+                  elsif Connection_Type = CT_Parameter then
+                     Type_String := Get_String_Name ("parameter");
+
+                  elsif Connection_Type = CT_Access_Bus then
+                     Type_String := Get_String_Name ("access_bus");
+
+                  elsif Connection_Type = CT_Access_Data then
+                     Type_String := Get_String_Name ("access_data");
+
+                  elsif Connection_Type = CT_Access_Subprogram then
+                     Type_String := Get_String_Name ("access_subprogram");
+
+                  --  AADL_V2
+                  elsif Connection_Type = CT_Access_Virtual_Bus then
+                     Type_String := Get_String_Name ("access_virtual_bus");
+
+                  elsif Connection_Type = CT_Feature then
+                     Type_String := Get_String_Name ("feature");
+
+                  elsif Connection_Type = CT_Port_Connection then
+                     Type_String := Get_String_Name ("port_connection");
+
+                  elsif Connection_Type = CT_Access_Subprogram_Group then
+                     Type_String :=
+                        Get_String_Name ("access_subprogram_group");
+
+                  else
+                     --  CT_Access
+                     Type_String := Get_String_Name ("access");
+                  end if;
+
+                  Append_Node_To_List
+                    (Make_Assignement
+                       (Make_Defining_Identifier (Get_String_Name ("type")),
+                        Make_Defining_Identifier (Type_String)),
+                     XTN.Items (Connection_Node));
+               end;
+            end if;
+
             --  Source and Destination
 
             declare

--- a/src/core/instance/ocarina-instances-components-connections.adb
+++ b/src/core/instance/ocarina-instances-components-connections.adb
@@ -7,7 +7,7 @@
 --                                 B o d y                                  --
 --                                                                          --
 --               Copyright (C) 2005-2009 Telecom ParisTech,                 --
---                 2010-2019 ESA & ISAE, 2019-2020 OpenAADL                 --
+--         2010-2019 ESA & ISAE, 2019-2021 OpenAADL, 2021 NVIDIA            --
 --                                                                          --
 -- Ocarina  is free software; you can redistribute it and/or modify under   --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -248,7 +248,7 @@ package body Ocarina.Instances.Components.Connections is
 
       --  Set the connection type
 
-      Set_Associated_Type (New_Instance, No_Node);
+      Set_Associated_Type (New_Instance, Node_Id (ATN.Category (Connection)));
 
       --  Apply the properties of the connection to the connection
       --  instance.

--- a/tests/github/issue_287/test_aadl_xml_connections.aadl
+++ b/tests/github/issue_287/test_aadl_xml_connections.aadl
@@ -8,11 +8,14 @@ public
 
     system implementation main.impl
         subcomponents
+            b1: bus dummy_bus.impl;
             p1: process dummy_process.impl;
             p2: process dummy_process.impl;
+            d1: device dummy_device.impl;
 
         connections
             conn1: port p1.out_port -> p2.in_port {Timing => Immediate; Latency => 1ms .. 10ms;};
+            conn2: bus access b1 <-> d1.b1;
     end main.impl;
 
     process dummy_process
@@ -40,5 +43,19 @@ public
 
     thread implementation dummy_thread.impl
     end dummy_thread.impl;
+
+    device dummy_device
+        features
+            b1: requires bus access dummy_bus;
+    end dummy_device;
+
+    device implementation dummy_device.impl
+    end dummy_device.impl;
+
+    bus dummy_bus
+    end dummy_bus;
+
+    bus implementation dummy_bus.impl
+    end dummy_bus.impl;
 
 end Test_Aadl_Xml_Connections;

--- a/tests/github/issue_287/test_aadl_xml_connections.aadl.out
+++ b/tests/github/issue_287/test_aadl_xml_connections.aadl.out
@@ -5,6 +5,13 @@
        main.impl     </classifier>
      <features/>
      <subcomponents>
+       <component category="bus" identifier="b1">
+         <classifier>
+           dummy_bus.impl         </classifier>
+         <features/>
+         <subcomponents/>
+         <properties/>
+       </component>
        <component category="process" identifier="p1">
          <classifier>
            dummy_process.impl         </classifier>
@@ -66,12 +73,12 @@
          </subcomponents>
          <properties/>
          <connections>
-           <connection name="conn1">
+           <connection name="conn1" type="port_connection">
              <src feature="in_port"/>
              <dst component="t1" feature="in_port"/>
              <properties/>
            </connection>
-           <connection name="conn2">
+           <connection name="conn2" type="port_connection">
              <src component="t1" feature="out_port"/>
              <dst component="t2" feature="in_port"/>
              <properties>
@@ -82,7 +89,7 @@
                </property>
              </properties>
            </connection>
-           <connection name="conn3">
+           <connection name="conn3" type="port_connection">
              <src component="t2" feature="out_port"/>
              <dst feature="out_port"/>
              <properties/>
@@ -150,12 +157,12 @@
          </subcomponents>
          <properties/>
          <connections>
-           <connection name="conn1">
+           <connection name="conn1" type="port_connection">
              <src feature="in_port"/>
              <dst component="t1" feature="in_port"/>
              <properties/>
            </connection>
-           <connection name="conn2">
+           <connection name="conn2" type="port_connection">
              <src component="t1" feature="out_port"/>
              <dst component="t2" feature="in_port"/>
              <properties>
@@ -166,17 +173,31 @@
                </property>
              </properties>
            </connection>
-           <connection name="conn3">
+           <connection name="conn3" type="port_connection">
              <src component="t2" feature="out_port"/>
              <dst feature="out_port"/>
              <properties/>
            </connection>
          </connections>
        </component>
+       <component category="device" identifier="d1">
+         <classifier>
+           dummy_device.impl         </classifier>
+         <features>
+           <feature identifier="b1">
+             <direction kind="none"/>
+             <type kind="access"/>
+             <classifier>
+               dummy_bus             </classifier>
+           </feature>
+         </features>
+         <subcomponents/>
+         <properties/>
+       </component>
      </subcomponents>
      <properties/>
      <connections>
-       <connection name="conn1">
+       <connection name="conn1" type="port_connection">
          <src component="p1" feature="out_port"/>
          <dst component="p2" feature="in_port"/>
          <properties>
@@ -191,6 +212,11 @@
              </property_value>
            </property>
          </properties>
+       </connection>
+       <connection name="conn2" type="access_bus">
+         <src feature="b1"/>
+         <dst component="d1" feature="b1"/>
+         <properties/>
        </connection>
      </connections>
    </component>


### PR DESCRIPTION
This commit adds connection type information (defined in `Ocarina.ME_AADL.Connection_Type`) to the connections in a model instance. The `aadl_xml` backend is revised to include the connection types in its output XML format accordingly.

This is considered a part of efforts for including more details in the XML format generated by the `aadl_xml` backedn discussed in GitHub Issue #287.