### PR TITLE
Fix a bug causing flow spec inconsistency errors

### DIFF
--- a/tests/MANIFEST
+++ b/tests/MANIFEST
@@ -335,6 +335,7 @@ tests/github/issue_287/test_lists.aadl
 tests/github/issue_287/test_property_terms.aadl
 tests/github/issue_287/test_aadl_xml_connections.aadl
 tests/github/issue_288/test_cheddar.aadl
+tests/github/issue_297/test_order.aadl
 
 tests/root_system/test.aadl
 

--- a/tests/github/issue_297/MANIFEST
+++ b/tests/github/issue_297/MANIFEST
@@ -1,0 +1,2 @@
+AADL_VERSION=-aadlv2
+OCARINA_FLAGS=-g aadl

--- a/tests/github/issue_297/test_order.aadl
+++ b/tests/github/issue_297/test_order.aadl
@@ -1,0 +1,56 @@
+package test_order
+public
+
+    data d1 end d1;
+
+
+    system deployment
+    end deployment;
+
+    system implementation deployment.impl
+        subcomponents
+            p1: process p1.impl;
+    end deployment.impl;
+
+
+    -- The extended component
+    -- An flow source inconsistency error was thrown wrongly
+    -- if p2 implementation is declared before p1 type is declared.
+    process p2
+    extends p1
+    end p2;
+
+    process implementation p2.impl
+    extends p1.impl
+    end p2.impl;
+    -- End of extend component
+
+
+    process p1
+        features
+            out_port: out data port d1;
+        flows
+            flow_out: flow source out_port;
+    end p1;
+
+    process implementation p1.impl
+        subcomponents
+            t1: thread t1.impl;
+        connections
+            conn_out: port t1.out_port -> out_port;
+        flows
+            flow_out: flow source t1.flow_out -> conn_out -> out_port;   -- where Ocarina throws an error against
+    end p1.impl;
+
+
+    thread t1
+        features
+            out_port: out data port d1;
+        flows
+            flow_out: flow source out_port;
+    end t1;
+
+    thread implementation t1.impl
+    end t1.impl;
+
+end test_order;

--- a/tests/github/issue_297/test_order.aadl.out
+++ b/tests/github/issue_297/test_order.aadl.out
@@ -1,0 +1,64 @@
+
+
+
+
+
+
+
+
+package test_order
+public
+  data d1
+  end d1;
+
+  system deployment
+  end deployment;
+
+  system implementation deployment.impl
+  subcomponents
+    p1 : process p1.impl;
+
+  end deployment.impl;
+
+  process p2 extends p1
+  end p2;
+
+  process implementation p2.impl extends p1.impl
+  end p2.impl;
+
+  process p1
+  features
+    out_port : out data port d1;
+
+  flows
+    flow_out : flow source out_port;
+
+  end p1;
+
+  process implementation p1.impl
+  subcomponents
+    t1 : thread t1.impl;
+
+  connections
+    conn_out : port t1.out_port -> out_port;
+
+  flows
+    flow_out : flow source t1.flow_out -> conn_out -> out_port
+;
+
+  end p1.impl;
+
+  thread t1
+  features
+    out_port : out data port d1;
+
+  flows
+    flow_out : flow source out_port;
+
+  end t1;
+
+  thread implementation t1.impl
+  end t1.impl;
+
+end test_order;
+

--- a/tests/test023/test.aadl.out
+++ b/tests/test023/test.aadl.out
@@ -1,10 +1,10 @@
-test.aadl:17:18: basic::string (entity reference) qualified reference name not found in 'with' statements of Test (package specification) 
-test.aadl:18:26: sei::Address (entity reference) qualified reference name not found in 'with' statements of Test (package specification) 
 test.aadl:30:27: basic::string (entity reference) qualified reference name not found in 'with' statements of Test (package specification) 
 test.aadl:31:25: basic::string (entity reference) qualified reference name not found in 'with' statements of Test (package specification) 
 test.aadl:51:06: new_person (port spec) points to Personnel_record (entity reference), which is not of an adequate kind
 test.aadl:51:06: new_person (port spec) does not point to anything or to something unreachable
 test.aadl:52:06: SEI_personnel (subcomponent access) does not point to anything or to something unreachable
+test.aadl:17:18: basic::string (entity reference) qualified reference name not found in 'with' statements of Test (package specification) 
+test.aadl:18:26: sei::Address (entity reference) qualified reference name not found in 'with' statements of Test (package specification) 
 test.aadl:74:21: basic::string (entity reference) qualified reference name not found in 'with' statements of sei (package specification) 
 test.aadl:75:26: basic::int (entity reference) qualified reference name not found in 'with' statements of sei (package specification) 
 test.aadl:76:18: basic::string (entity reference) qualified reference name not found in 'with' statements of sei (package specification) 


### PR DESCRIPTION
As stated in GitHub issue #297, a flow spec inconsistency error is thrown when a component's implementation is declared before its component type (including the type it is extending) is declared.

This commit resovles this issue by processing all component type declarations first before all other implemenations are processed
in the analyzer's linking stage.
