### PR TITLE
Fix and improve property value representations in aadl_xml

### DIFF
--- a/resources/runtime/aadl_xml/aadl.xsd
+++ b/resources/runtime/aadl_xml/aadl.xsd
@@ -77,6 +77,7 @@
   
   <xs:element name='classifier'>
     <xs:complexType mixed='true'>
+      <xs:attribute name='namespace' type="xs:string" use='required'/>
     </xs:complexType>
   </xs:element>
   

--- a/resources/runtime/aadl_xml/aadl.xsd
+++ b/resources/runtime/aadl_xml/aadl.xsd
@@ -220,6 +220,7 @@
       <xs:element name="number" type="unit_prop"/>
       <xs:element name="range" type="range_prop"/>
       <xs:element name="string" type="string_prop"/>
+      <xs:element name="boolean" type="boolean_prop"/>
       <xs:element ref="record"/>
       <xs:element ref="list"/>
     </xs:choice>
@@ -234,6 +235,7 @@
         <xs:element name="number" type="unit_prop"/>
         <xs:element name="range" type="range_prop"/>
         <xs:element name="string" type="string_prop"/>
+        <xs:element name="boolean" type="boolean_prop"/>
         <xs:element ref="record"/>
         <xs:element ref="list"/>
       </xs:choice>
@@ -273,6 +275,10 @@
 
   <xs:complexType name='string_prop'>
     <xs:attribute name='value' type="xs:string" use='required'/>
+  </xs:complexType>
+
+  <xs:complexType name='boolean_prop'>
+    <xs:attribute name='value' type="xs:boolean" use='required'/>
   </xs:complexType>
 
   <xs:complexType name='reference_prop'>

--- a/src/backends/aadl_xml/ocarina-backends-aadl_xml-main.adb
+++ b/src/backends/aadl_xml/ocarina-backends-aadl_xml-main.adb
@@ -623,18 +623,43 @@ package body Ocarina.Backends.AADL_XML.Main is
       then
          --  This property value denotes a reference term
 
-         Value_Node := Make_XML_Node ("reference");
+         declare
+            Full_Reference_Name : Name_Id;
+            Is_First_Node       : Boolean := TRUE;
+         begin
+            Value_Node := Make_XML_Node ("reference");
 
-         Append_Node_To_List
-           (Make_Assignement
-              (Make_Defining_Identifier (Get_String_Name ("value")),
-               Make_Defining_Identifier
-               (ATN.Display_Name
-                  (ATN.First_Node --  XXX must iterate
-                     (ATN.List_Items
-                        (ATN.Reference_Term
-                           (AADL_Property_Value)))))),
-            XTN.Items (Value_Node));
+            List_Node :=
+              ATN.First_Node
+                (ATN.List_Items
+                  (ATN.Reference_Term
+                     (AADL_Property_Value)));
+
+            while Present (List_Node) loop
+               if Is_First_Node then
+                  Full_Reference_Name := ATN.Display_Name (List_Node);
+                  Is_First_Node := FALSE;
+
+               else
+                  Full_Reference_Name :=
+                    Add_Suffix_To_Name
+                      (".", Full_Reference_Name);
+
+                  Full_Reference_Name :=
+                    Add_Suffix_To_Name
+                      (Get_Name_String (ATN.Display_Name (List_Node)),
+                       Full_Reference_Name);
+               end if;
+
+               List_Node := ATN.Next_Node (List_Node);
+            end loop;
+
+            Append_Node_To_List
+              (Make_Assignement
+                 (Make_Defining_Identifier (Get_String_Name ("value")),
+                  Make_Defining_Identifier (Full_Reference_Name)),
+               XTN.Items (Value_Node));
+         end;
 
       elsif Present (AADL_Property_Value)
         and then ATN.Kind (AADL_Property_Value) =

--- a/src/backends/aadl_xml/ocarina-backends-aadl_xml-main.adb
+++ b/src/backends/aadl_xml/ocarina-backends-aadl_xml-main.adb
@@ -134,6 +134,15 @@ package body Ocarina.Backends.AADL_XML.Main is
       Append_Node_To_List
         (Make_Defining_Identifier (Display_Name (Identifier (E))),
          XTN.Subitems (Classifier_Node));
+
+      --  Add namespace attribute to the classifier node
+      Append_Node_To_List
+        (Make_Assignement
+           (Make_Defining_Identifier (Get_String_Name ("namespace")),
+            Make_Defining_Identifier
+              (Display_Name (Identifier (Namespace (E))))),
+         XTN.Items (Classifier_Node));
+
       Append_Node_To_List (Classifier_Node, XTN.Subitems (N));
 
       return N;

--- a/tests/github/issue_287/test_aadl_xml.aadl.out
+++ b/tests/github/issue_287/test_aadl_xml.aadl.out
@@ -1,7 +1,7 @@
 <aadl_xml root_system="main.impl">
  <components>
    <component category="system" identifier="main.impl">
-     <classifier>
+     <classifier namespace="Test_Aadl_Xml_Output">
        main.impl     </classifier>
      <features/>
      <subcomponents/>

--- a/tests/github/issue_287/test_aadl_xml_connections.aadl.out
+++ b/tests/github/issue_287/test_aadl_xml_connections.aadl.out
@@ -1,19 +1,19 @@
 <aadl_xml root_system="main.impl">
  <components>
    <component category="system" identifier="main.impl">
-     <classifier>
+     <classifier namespace="Test_Aadl_Xml_Connections">
        main.impl     </classifier>
      <features/>
      <subcomponents>
        <component category="bus" identifier="b1">
-         <classifier>
+         <classifier namespace="Test_Aadl_Xml_Connections">
            dummy_bus.impl         </classifier>
          <features/>
          <subcomponents/>
          <properties/>
        </component>
        <component category="process" identifier="p1">
-         <classifier>
+         <classifier namespace="Test_Aadl_Xml_Connections">
            dummy_process.impl         </classifier>
          <features>
            <feature identifier="in_port">
@@ -21,7 +21,7 @@
              <type kind="data"/>
              <corresponding_instance>
                <component category="data" identifier="dummy_data">
-                 <classifier>
+                 <classifier namespace="Test_Aadl_Xml_Connections">
                    dummy_data                 </classifier>
                  <features/>
                  <subcomponents/>
@@ -34,7 +34,7 @@
              <type kind="data"/>
              <corresponding_instance>
                <component category="data" identifier="dummy_data">
-                 <classifier>
+                 <classifier namespace="Test_Aadl_Xml_Connections">
                    dummy_data                 </classifier>
                  <features/>
                  <subcomponents/>
@@ -45,7 +45,7 @@
          </features>
          <subcomponents>
            <component category="thread" identifier="t1">
-             <classifier>
+             <classifier namespace="Test_Aadl_Xml_Connections">
                dummy_thread.impl             </classifier>
              <features>
                <feature identifier="in_port">
@@ -53,7 +53,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -66,7 +66,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -79,7 +79,7 @@
              <properties/>
            </component>
            <component category="thread" identifier="t2">
-             <classifier>
+             <classifier namespace="Test_Aadl_Xml_Connections">
                dummy_thread.impl             </classifier>
              <features>
                <feature identifier="in_port">
@@ -87,7 +87,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -100,7 +100,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -139,7 +139,7 @@
          </connections>
        </component>
        <component category="process" identifier="p2">
-         <classifier>
+         <classifier namespace="Test_Aadl_Xml_Connections">
            dummy_process.impl         </classifier>
          <features>
            <feature identifier="in_port">
@@ -147,7 +147,7 @@
              <type kind="data"/>
              <corresponding_instance>
                <component category="data" identifier="dummy_data">
-                 <classifier>
+                 <classifier namespace="Test_Aadl_Xml_Connections">
                    dummy_data                 </classifier>
                  <features/>
                  <subcomponents/>
@@ -160,7 +160,7 @@
              <type kind="data"/>
              <corresponding_instance>
                <component category="data" identifier="dummy_data">
-                 <classifier>
+                 <classifier namespace="Test_Aadl_Xml_Connections">
                    dummy_data                 </classifier>
                  <features/>
                  <subcomponents/>
@@ -171,7 +171,7 @@
          </features>
          <subcomponents>
            <component category="thread" identifier="t1">
-             <classifier>
+             <classifier namespace="Test_Aadl_Xml_Connections">
                dummy_thread.impl             </classifier>
              <features>
                <feature identifier="in_port">
@@ -179,7 +179,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -192,7 +192,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -205,7 +205,7 @@
              <properties/>
            </component>
            <component category="thread" identifier="t2">
-             <classifier>
+             <classifier namespace="Test_Aadl_Xml_Connections">
                dummy_thread.impl             </classifier>
              <features>
                <feature identifier="in_port">
@@ -213,7 +213,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -226,7 +226,7 @@
                  <type kind="data"/>
                  <corresponding_instance>
                    <component category="data" identifier="dummy_data">
-                     <classifier>
+                     <classifier namespace="Test_Aadl_Xml_Connections">
                        dummy_data                     </classifier>
                      <features/>
                      <subcomponents/>
@@ -265,7 +265,7 @@
          </connections>
        </component>
        <component category="device" identifier="d1">
-         <classifier>
+         <classifier namespace="Test_Aadl_Xml_Connections">
            dummy_device.impl         </classifier>
          <features>
            <feature identifier="b1">
@@ -273,7 +273,7 @@
              <type kind="access"/>
              <corresponding_instance>
                <component category="bus" identifier="dummy_bus">
-                 <classifier>
+                 <classifier namespace="Test_Aadl_Xml_Connections">
                    dummy_bus                 </classifier>
                  <features/>
                  <subcomponents/>

--- a/tests/github/issue_287/test_lists.aadl.out
+++ b/tests/github/issue_287/test_lists.aadl.out
@@ -1,7 +1,7 @@
 <aadl_xml root_system="main.impl">
  <components>
    <component category="system" identifier="main.impl">
-     <classifier>
+     <classifier namespace="Test_List_of_List">
        main.impl     </classifier>
      <features/>
      <subcomponents/>

--- a/tests/github/issue_287/test_property_terms.aadl
+++ b/tests/github/issue_287/test_property_terms.aadl
@@ -39,7 +39,7 @@ public
 
   system implementation main.impl
     subcomponents
-      subcomp_subdevice: device subdevice.impl;
+      subcomp_process: process dummy_process.impl;
     properties
 
       Test_Properties::an_integer_property => 10;
@@ -58,9 +58,9 @@ public
 
       Test_Properties::a_list_of_list_property => ((1,2), (3,4));
 
-      Test_Properties::a_reference_property => reference (subcomp_subdevice);
+      Test_Properties::a_reference_property => reference (subcomp_process.subcomp_thread);
 
-      Test_Properties::a_classifier_property => classifier (subdevice);
+      Test_Properties::a_classifier_property => classifier (dummy_process.impl);
 
       Test_Properties::an_enumeration_property => enum2;
 
@@ -68,10 +68,18 @@ public
 
   end main.impl;
 
-  device subdevice
-  end subdevice;
+  process dummy_process
+  end dummy_process;
 
-  device implementation subdevice.impl
-  end subdevice.impl;
+  process implementation dummy_process.impl
+    subcomponents
+      subcomp_thread: thread dummy_thread.impl;
+  end dummy_process.impl;
+
+  thread dummy_thread
+  end dummy_thread;
+
+  thread implementation dummy_thread.impl
+  end dummy_thread.impl;
 
 end Test;

--- a/tests/github/issue_287/test_property_terms.aadl.out
+++ b/tests/github/issue_287/test_property_terms.aadl.out
@@ -1,17 +1,17 @@
 <aadl_xml root_system="main.impl">
  <components>
    <component category="system" identifier="main.impl">
-     <classifier>
+     <classifier namespace="Test">
        main.impl     </classifier>
      <features/>
      <subcomponents>
        <component category="process" identifier="subcomp_process">
-         <classifier>
+         <classifier namespace="Test">
            dummy_process.impl         </classifier>
          <features/>
          <subcomponents>
            <component category="thread" identifier="subcomp_thread">
-             <classifier>
+             <classifier namespace="Test">
                dummy_thread.impl             </classifier>
              <features/>
              <subcomponents/>

--- a/tests/github/issue_287/test_property_terms.aadl.out
+++ b/tests/github/issue_287/test_property_terms.aadl.out
@@ -5,11 +5,19 @@
        main.impl     </classifier>
      <features/>
      <subcomponents>
-       <component category="device" identifier="subcomp_subdevice">
+       <component category="process" identifier="subcomp_process">
          <classifier>
-           subdevice.impl         </classifier>
+           dummy_process.impl         </classifier>
          <features/>
-         <subcomponents/>
+         <subcomponents>
+           <component category="thread" identifier="subcomp_thread">
+             <classifier>
+               dummy_thread.impl             </classifier>
+             <features/>
+             <subcomponents/>
+             <properties/>
+           </component>
+         </subcomponents>
          <properties/>
        </component>
      </subcomponents>
@@ -36,12 +44,12 @@
        </property>
        <property name="Test_Properties::a_classifier_property">
          <property_value>
-           <classifier value="subdevice"/>
+           <classifier value="dummy_process.impl"/>
          </property_value>
        </property>
        <property name="Test_Properties::a_reference_property">
          <property_value>
-           <reference value="subcomp_subdevice"/>
+           <reference value="subcomp_process.subcomp_thread"/>
          </property_value>
        </property>
        <property name="Test_Properties::a_list_of_list_property">


### PR DESCRIPTION
This pull request contains three commits that address the following issues for the `aadl_xml` backend:
- Fixed an issue for correctly outputting reference type property values
- Added a namespace attribute in a component's classifier (so that we are able to obtain the component's full name -- full classifier and package name)
- Fixed aadl_xml's XSD for the boolean property value type

These changes are related to #287 and #300.